### PR TITLE
Escape "@" for some vue.js web application

### DIFF
--- a/toolatra_templates.tcl
+++ b/toolatra_templates.tcl
@@ -32,22 +32,22 @@ proc _toolatra_template_load {relPath {context -1}} {
                   	if {$cchar2=="@"} {
                         	incr index ;
                         	set result "$result@" ;
-                      	} else  {
-				if {$insideEval} {
-					set insideEval 0
-					if {[info exists $tmpEval]} {
-						set result "$result[eval "_toolatra_varpingpong \$$tmpEval"]"
-					} elseif {[string index $tmpEval 0] == {!}} {
-						set substrTmpEval [string trim [string range $tmpEval 1 end]]
-						set result "$result[layout $substrTmpEval $context]"
-					} else {
-						set result "$result[eval $tmpEval]"
-					}
-					set tmpEval ""
+				continue ;
+                      	}
+			if {$insideEval} {
+				set insideEval 0
+				if {[info exists $tmpEval]} {
+					set result "$result[eval "_toolatra_varpingpong \$$tmpEval"]"
+				} elseif {[string index $tmpEval 0] == {!}} {
+					set substrTmpEval [string trim [string range $tmpEval 1 end]]
+					set result "$result[layout $substrTmpEval $context]"
 				} else {
-					set insideEval 1
-					set tmpEval ""
+					set result "$result[eval $tmpEval]"
 				}
+				set tmpEval ""
+			} else {
+				set insideEval 1
+				set tmpEval ""
 			}
 		} elseif {$insideEval} {
 			set tmpEval "$tmpEval$cchar"

--- a/toolatra_templates.tcl
+++ b/toolatra_templates.tcl
@@ -28,20 +28,26 @@ proc _toolatra_template_load {relPath {context -1}} {
 	for {set index 0} {$index < [string length $contents]} {incr index} {
 		set cchar [string index $contents $index]
 		if {$cchar == "@"} {
-			if {$insideEval} {
-				set insideEval 0
-				if {[info exists $tmpEval]} {
-					set result "$result[eval "_toolatra_varpingpong \$$tmpEval"]"
-				} elseif {[string index $tmpEval 0] == {!}} {
-					set substrTmpEval [string trim [string range $tmpEval 1 end]]
-					set result "$result[layout $substrTmpEval $context]"
+			set cchar2 [string index $contents [expr $index+1]]
+                  	if {$cchar2=="@"} {
+                        	incr index ;
+                        	set result "$result@" ;
+                      	} else  {
+				if {$insideEval} {
+					set insideEval 0
+					if {[info exists $tmpEval]} {
+						set result "$result[eval "_toolatra_varpingpong \$$tmpEval"]"
+					} elseif {[string index $tmpEval 0] == {!}} {
+						set substrTmpEval [string trim [string range $tmpEval 1 end]]
+						set result "$result[layout $substrTmpEval $context]"
+					} else {
+						set result "$result[eval $tmpEval]"
+					}
+					set tmpEval ""
 				} else {
-					set result "$result[eval $tmpEval]"
+					set insideEval 1
+					set tmpEval ""
 				}
-				set tmpEval ""
-			} else {
-				set insideEval 1
-				set tmpEval ""
 			}
 		} elseif {$insideEval} {
 			set tmpEval "$tmpEval$cchar"


### PR DESCRIPTION
Thanks for your great tcl web framework.
When I use it to render the vue based web application templates.
I have this:

```
<local-codemirror ref="cmA"
  :value="code2"
  :options="cmOption2"
  @blur="onCmBlur($event)"
  @focus="onCmFocus($event)"
  @ready="onCmReady($event)"
  @input="onCmInput"
>
</local-codemirror>
```

I need to escape the symbol "@", I add a very small piece of tcl into the toolatra_templates.tcl file to escape "@" using "@@".

Thanks
Steve